### PR TITLE
Combat: Fix ambiguity, spelling, grammar, and or punctuation.

### DIFF
--- a/Module/04-Combat/action-attack_melee.md
+++ b/Module/04-Combat/action-attack_melee.md
@@ -12,7 +12,7 @@ parent: action
 - weapons with [finesse](weapon-properties) property may use a creatures's [strength](strength) or [dexterity](dexterity) modifier.
 - In some situations a creature may have [advantage or disadvantage](advantage-and-disadvantage) on the roll.
 
-***\*** The character must be proficient with the weapon being used to add their [proficiency bonus](proficiency-bonus) to the roll.* {.small-text}
+***\*** A character must be proficient with the weapon being used to add their [proficiency bonus](proficiency-bonus) to the roll.* {.small-text}
 
 > **Sources** <br/>
 > System Reference Document, p. <br/>

--- a/Module/04-Combat/action-attack_ranged.md
+++ b/Module/04-Combat/action-attack_ranged.md
@@ -13,7 +13,7 @@ parent: action
 - Ranged attacks against targets in melee range are made with [Disadvantage](advantage-and-disadvantage).
 {.square}
 
-***\*** The character must be proficient with the weapon being used to add their [proficiency bonus](proficiency-bonus) to the roll.* {.small-text}
+***\*** A character must be proficient with the weapon being used to add their [proficiency bonus](proficiency-bonus) to the roll.* {.small-text}
 
 > **Sources** <br/>
 > System Reference Document, p. <br/>

--- a/Module/04-Combat/action-cast_spell.md
+++ b/Module/04-Combat/action-cast_spell.md
@@ -13,7 +13,7 @@ Cast a spell with a casting time of 1 [action](action). {.text-center}
 ***Note**: If a [bonus action](bonus-action) spell has been cast, any spell cast using an [action](action) **MUST** be a cantrip.*
 {.square .small-text}
 
-*A spellcaster must be proficient with a class of [armor](armor) in order to be able to cast spells while wearing it.* {.small-text}
+*A spellcaster must be proficient with a class of [armor](armor) to cast spells while wearing it.* {.small-text}
 
 > **Sources** <br/>
 > System Reference Document, p. 93<br/>

--- a/Module/04-Combat/action-disengage.md
+++ b/Module/04-Combat/action-disengage.md
@@ -11,4 +11,4 @@ Movement does not provoke any [opportunity attacks](opportunity-attack) for the 
 > **Sources** <br/>
 > System Reference Document, p. 93<br/>
 > Player's Handbook, p. 192
-{.read .small-text}
+{.read .small-text} 

--- a/Module/04-Combat/action-dodge.md
+++ b/Module/04-Combat/action-dodge.md
@@ -6,9 +6,9 @@ parent: action
 ### Dodge
 [Home](dm-operations-center) > [Combat](combat-menu) > [Action](action) > Dodge {.small-text}
 
-[Disadvantage](advantage-and-disadvantage) on attacks against & [Advantage](advantage-and-disadvantage) on [Dexterity](dexterity) [saves](saving-throws) until start of the next turn. {.text-center}
+[Disadvantage](advantage-and-disadvantage) on attacks against & [Advantage](advantage-and-disadvantage) on [Dexterity](dexterity) [saves](saving-throws) until the start of the next turn. {.text-center}
 
-***Note**: The character must be able to see the attack, have a speed > 0, and is not [incapacitated](incapacitated).* {.small-text}
+***Note**: A character must be able to see the attack, have a speed > 0, and is not [incapacitated](incapacitated).* {.small-text}
 
 > **Sources** <br/>
 > System Reference Document, p. <br/>

--- a/Module/04-Combat/action-help.md
+++ b/Module/04-Combat/action-help.md
@@ -6,7 +6,7 @@ parent: action
 ### Help
 [Home](dm-operations-center) > [Combat](combat-menu) > [Action](action) > Help {.small-text}
 
-Give [advantage](advantage-and-disadvantage) to another creature on it's next check or attack if the helper is within 5' of target. {.text-center}
+Give [advantage](advantage-and-disadvantage) to another creature on its next check or attack if the helper is within 5' of a target. {.text-center}
 
 
  

--- a/Module/04-Combat/action-use_object.md
+++ b/Module/04-Combat/action-use_object.md
@@ -10,7 +10,7 @@ Interact with or use an object that<br/> requires an [action](action) to operate
 
 OR {.text-center}
 
-Perform more than 1 [free action](free-action) in a turn. {.text-center}
+Perform more than 1 [free action](free-action) on a turn. {.text-center}
 
 > **Sources** <br/>
 > System Reference Document, p. 94 <br/>

--- a/Module/04-Combat/bonus_action.md
+++ b/Module/04-Combat/bonus_action.md
@@ -11,7 +11,7 @@ parent: combat
 {.square}
 
 **Common Examples**
-- Off-hand Attack. ([two weapon fighting](two-weapon-fighting))
+- Off-hand Attack. ([two-weapon fighting](two-weapon-fighting))
 - Cast [Healing Word](/spell/healing-word) or [Hunter's Mark](/spell/hunters-mark)
 - [Dash](dash), [disengage](disengage), or [dodge](dodge) (Rogues)
 - [Wild Shape](wild-shape) (Circle of the Moon Druid)

--- a/Module/04-Combat/critical_hit_and_miss.md
+++ b/Module/04-Combat/critical_hit_and_miss.md
@@ -6,18 +6,17 @@ parent: combat
 ## Critical Hit & Miss
 [Home](dm-operations-center) > [Combat](combat-menu) > Critical Hit & Miss {.small-text}
 
-**Critical Hit**. An automatic hit in which **ALL** damage dice for the attack are doubled. {.text-center}
+**Critical Hit**. An automatic hit in which **all** damage dice for the attack are doubled. {.text-center}
 
-*Includes [sneak attack](sneak-attack), spells, extra damage, etc.* {.text-center .small-text}
+*This includes [sneak attacks](sneak-attack), spells, extra damage, etc.* {.text-center .small-text}
 
 <br/>
 
 Roll the damage dice once and double it. {.text-center}
 
-OR  {.text-center}
+OR {.text-center}
 
 Roll the damage dice for the attack twice. {.text-center}
-
 
 **Critical Miss**. An automatic miss regardless of modifiers and the target's [armor class](armor-class).
 

--- a/Module/04-Combat/free_action.md
+++ b/Module/04-Combat/free_action.md
@@ -6,8 +6,8 @@ parent: combat
 ### Free Action
 [Home](dm-operations-center) > [Combat](combat-menu) > Free Action {.small-text}
 
-- Interactions that do no require an [action](action).
-- Simple communications and gestures.
+- Interactions that do no require an [action](action)
+- Simple communications and gestures
 - Draw or sheathe a sword
 - Open or close a door
 - Withdraw a potion from your backpack

--- a/Module/04-Combat/grapple_and_shove.md
+++ b/Module/04-Combat/grapple_and_shove.md
@@ -12,19 +12,19 @@ parent: combat
 {.gray .small-text}
 
 - A grapple or shove is a [melee attack](attack-melee).
-- It may be used with [extra attack](extra-attack).
+- It may be used with an [extra attack](extra-attack).
 - Target no more than 1 size larger.
-- Auto succeeds if target is [incapacitated](incapacitated).
+- Auto succeeds if the target is [incapacitated](incapacitated).
 {.square}
 
 #### Grapple
 If successful, the target creature is [grappled](grappled).
 - A creature can use its [action](action) to escape.
-- A creature's speed is halved when dragging or carrying [grappled](grappled) creature, unless it is two or more sizes smaller.
+- A creature's speed is halved when dragging or carrying another [grappled](grappled) creature unless it is two or more sizes smaller.
 {.square}
 
 #### Shove
-If successful the target is knocked [prone](prone) OR pushed 5' from the attacker.
+If successful, the target is knocked [prone](prone) OR pushed 5' from the attacker.
 
 > **Sources** <br/>
 > System Reference Document, p. 95<br/>

--- a/Module/04-Combat/improvised_weapon.md
+++ b/Module/04-Combat/improvised_weapon.md
@@ -8,10 +8,10 @@ parent: combat
 
 - Use stats for a comparable [weapon](weapons)
 - If nothing comparable, use [1d4](/roll/1d4)
-- Add [proficiency](proficiency-bonus) if similar to proficient [weapon](weapons)
+- Add [proficiency](proficiency-bonus) modifier if similar to a proficient [weapon](weapons)
 - DM determines appropriate [damage type](damage-type)
-- [Thrown](weapon-properties) [weapon](weapons) w/o the property do [1d4](/roll/1d4)
-- Non-Thrown [weapon](weapons) have 20/60 range.
+- [Thrown](weapon-properties) [weapons](weapons) w/o the property do [1d4](/roll/1d4)
+- Non-Thrown [weapons](weapons) have 20/60 range
 {.square}
 
 > **Sources** <br/>

--- a/Module/04-Combat/mounted_combat.md
+++ b/Module/04-Combat/mounted_combat.md
@@ -13,12 +13,12 @@ parent: combat
 {.square}
 
 #### Getting Knocked Off
-[DC](difficulty-class) 10 [DEX](DEXTERITY) [Save](saving-throws) to avoid falling off and landing [prone](prone) within 5' of the mount if:
+Must succeed on a [DC](difficulty-class) 10 [DEX](DEXTERITY) [Save](saving-throws) to avoid falling off and landing [prone](prone) within 5' of a mount if:
 - Mount is moved against its will.
 - Rider is knocked [prone](prone) while riding.
 {.square}
 
-If the mount is knocked [prone](prone), the rider may use their [reaction](reaction) to land on their feet, or they fall [prone](prone) within 5' of the mount.
+If a mount is knocked [prone](prone), a rider may use their [reaction](reaction) to land on their feet, or fall [prone](prone) within 5' of the mount.
 
 #### Controlling a Mount
 | Type                                                 | Initiative | Actions                                       |
@@ -27,7 +27,7 @@ If the mount is knocked [prone](prone), the rider may use their [reaction](react
 | **Independent**: Intelligent, sentient creatures.      | Mount's | No restrictions on actions                           |
 {.gray .small-text}
 
-If the mount provokes and [attack of opportunity](opportunity-attack), the attacker may target the mount or the rider.
+If a mount provokes an [attack of opportunity](opportunity-attack), the attacker may target the mount or the rider.
 
 > **Sources** <br/>
 > System Reference Document, p. 99<br/>

--- a/Module/04-Combat/nonlethal_damage.md
+++ b/Module/04-Combat/nonlethal_damage.md
@@ -10,7 +10,7 @@ parent: combat
 - The creature is automatically rendered [unconscious](unconscious) and [stabilized](stabilizing).
 {.square}
 
-***Note:** It does not matter how much damage is dealt, the target is "knocked out".*
+***Note:** It does not matter how much damage is dealt. The target is "knocked out".*
 
 > **Sources** <br/>
 > System Reference Document, p. 98<br/>

--- a/Module/04-Combat/object_ac_and_hp.md
+++ b/Module/04-Combat/object_ac_and_hp.md
@@ -27,9 +27,10 @@ parent: combat
 - All objects are immune to poison & psychic damage.
 {.square}
 
-**Damage Threshhold**<br/>
-Hardened objects are [immune](resistance-and-vulnerability) to all damage unless the amount of damage in a single attack exceeds a certain number.
+**Damage Threshold**<br/>
+Hardened objects are [immune](resistance-and-vulnerability) to all damage unless the amount of damage in a single attack exceeds its damage threshold.
 
 > **Sources** <br/>
+> System Reference Document, p. 203<br/>
 > Dungeon Masters' Guide, p. 246
 {.read .small-text}

--- a/Module/04-Combat/opportunity_attack.md
+++ b/Module/04-Combat/opportunity_attack.md
@@ -9,7 +9,7 @@ parent: combat
 - Initiated when a creature moves out of reach.
 - Occurs before the creature moves out of reach.
 - Requires the attacker to use their [reaction](reaction).
-- [Disengage](disengage) prevents an opportunity attacks.
+- [Disengage](disengage) prevents an opportunity attack.
 - Not triggered if the target isn't using movement.
 
 *Alternate: Attack of Opportunity* {.small-text}

--- a/Module/04-Combat/reaction.md
+++ b/Module/04-Combat/reaction.md
@@ -9,7 +9,7 @@ parent: combat
 1 Reaction per Round of Combat. {.text-center}
 
 **Examples**
-- [Cast a spell](cast-spell) with cast time of **1 reaction**.
+- [Cast a spell](cast-spell) with a cast time of **1 reaction**.
 - [Identifying a spell](identify-spell) as it is being cast.
 - Make an [opportunity attack](opportunity-attack).
 - Perform a [readied](ready) action.

--- a/Module/04-Combat/resistance_and_vulnerability.md
+++ b/Module/04-Combat/resistance_and_vulnerability.md
@@ -8,14 +8,14 @@ parent: combat
 
 |||
 | :------------ | :--------- |
-| Resistance    | 1/2 Damage |
+| Resistance    | ^1^/~2~ Damage |
 | Immunity      | No Damage  |
 | Vulnerability | 2x Damage  |
 {.gray .small-text}
 
 - Applied after all other damage modifiers
 - Apply to a specific [damage type](damage-type) only
-- Does not stack for same [damage type](damage-type)
+- Does not stack for the same [damage type](damage-type)
 {.square}
 
 

--- a/Module/04-Combat/two_weapon_fighting.md
+++ b/Module/04-Combat/two_weapon_fighting.md
@@ -8,8 +8,8 @@ parent: combat
 
 - Must use attack [action](action) for bonus attack.
 - Both weapons must be [light](weapon-properties) weapons.
-- [STR](STRENGTH) or [DEX](DEXTERITY) mod is not added to damage roll, unless it is negative.
-- Allowed for [ranged attacks](attack-ranged) with [thrown](weapon-properties)) property.
+- [STR](STRENGTH) or [DEX](DEXTERITY) mod is not added to the damage roll, unless it is negative.
+- Allowed for [ranged attacks](attack-ranged) with the [thrown](weapon-properties) property.
 
 > **Sources** <br/>
 > System Reference Document, p. 95<br/>

--- a/Module/04-Combat/unarmed_strike.md
+++ b/Module/04-Combat/unarmed_strike.md
@@ -8,7 +8,7 @@ parent: combat
 
 **Bludgeoning = 1 + [Strength](strength) [modifier](ability-modifiers)** {.text-center}
 
-- May be used in place of any [melee attack](attack-melee) including w/ [extra attack](extra-attack) or [bonus action](bonus-action)
+- May be used in place of any [melee attack](attack-melee), including w/ [extra attack](extra-attack) or [bonus action](bonus-action)
 - [Bonus action](bonus-action) unarmed strike, 1st attack must be w/ [light](weapon-properties) weapon or unarmed
 {.square}
 

--- a/Module/04-Combat/underwater_combat.md
+++ b/Module/04-Combat/underwater_combat.md
@@ -8,7 +8,7 @@ parent: combat
 
 |||
 | :--------- | :------------------------------------------------------------------------------------------------------------------------- |
-| **Melee**  | Attacker has a [swim](swim) speed **OR** weapon is a [dagger](/item/dagger), [javelin](/item/javelin), [shortsword](/item/shortsword), [spear](/item/spear), or [trident](/item/trident) |
+| **Melee**  | An attacker has a [swim](swim) speed **or** weapon is a [Dagger](/item/dagger), [Javelin](/item/javelin), [Shortsword](/item/shortsword), [Spear](/item/spear), or [Trident](/item/trident). |
 | **Ranged** | Crossbows, [Net](/item/net), [Spear](/item/spear), [Trident](/item/trident), [Dart](/item/dart) - Attacks beyond normal range automatically miss.|
 {.gray .small-text} 
 


### PR DESCRIPTION
This pull request should help with issue #52, the Combat task.

_Special note:_
On the object_ac_and_hp.md page, the "Damage Threshold" paragraph read "exceeds a certain number," which was ambiguous. I wasn't familiar with this rule as I haven't used it myself, so I lookup up the rule in the SRD and changed the text to "exceeds its damage threshold." I then added the SRD page reference. This particular edit teeters on changing content and just proofing/editing the page. While I don't think I changed the intent behind the original text, I may have inadvertently changed its context (and, therefore, content) while attempting to remove ambiguity. 
