### PR TITLE
Upkeep missing space and p on coin value, Known & Prepared Spells lin…

### DIFF
--- a/Module/06-Downtime/research.md
+++ b/Module/06-Downtime/research.md
@@ -9,7 +9,7 @@ parent: downtime
 
 | Lifestyle                   | Time   | Cost   | Other                        |
 | :-------------------------- | -----: | -----: | :--------------------------- |
-| [Modest](lifestyle-expense) |     1w |   50gp | Access to a sage or library. |
+| [Modest](lifestyle-expense) |     1w |  50 gp | Access to a sage or library. |
 {.gray .small-text}
 
 #### Resolution

--- a/Module/06-Downtime/sell_magic_item.md
+++ b/Module/06-Downtime/sell_magic_item.md
@@ -6,9 +6,9 @@ parent: downtime
 ### Sell Magic Item
 [Home](dm-operations-center) > [Downtime](downtime-menu) > Sell Magic Item {.small-text}
 
-| Lifestyle | Time | Cost | Other |
+| Lifestyle   | Time   | Cost   | Other   |
 | :---------- | -----: | -----: | :------ |
-| N/A         |     1w |   25gp | -       |
+| N/A         |     1w |  25 gp | -       |
 {.gray .small-text}
 
 #### Resolution
@@ -21,13 +21,13 @@ Character makes a [Charisma](charisma) ([Persuasion](persuasion)) check:
 |  21+  | 150% of base price. |
 {.gray .small-text}
 
-| Rarity  |  Price* |     from Buy Magic Item |
-| :-------- | --------: | ------------------------------: |
-| Common    |     100gp |     ([1d6](/roll/1d6)+1) x 10gp |
-| Uncommon  |     400gp |        [1d6](/roll/1d6) x 100gp |
-| Rare      |   4,000gp |    [2d10](/roll/2d10) x 1,000gp |
-| Very Rare |  40,000gp | ([1d4](/roll/1d4)+1) x 10,000gp |
-| Legendary | 200,000gp |     [2d6](/roll/2d6) x 25,000gp |
+| Rarity    |  Price*    |              from Buy Magic Item |
+| :-------- | ---------: | -------------------------------: |
+| Common    |     100 gp |     ([1d6](/roll/1d6)+1) x 10 gp |
+| Uncommon  |     400 gp |        [1d6](/roll/1d6) x 100 gp |
+| Rare      |   4,000 gp |    [2d10](/roll/2d10) x 1,000 gp |
+| Very Rare |  40,000 gp | ([1d4](/roll/1d4)+1) x 10,000 gp |
+| Legendary | 200,000 gp |     [2d6](/roll/2d6) x 25,000 gp |
 {.gray .small-text}
 
 ***\*** I prefer the pricing from [Buy Magic Item](buy-magic-item).* {.small-text}

--- a/Module/07-Encounters/07-encounters-menu.md
+++ b/Module/07-Encounters/07-encounters-menu.md
@@ -8,7 +8,7 @@ parent: dm-operations-center
 
 #### Gondor calls for aid! {.text-center}
 
-![Gondor calls for aid!](../assets/img/lotr-gondor.gif)
+![Gondor calls for aid!](../assets/img/lotr-gondor.gif) {.text-center}
 
 I have ambitious plans for this module and a limited amount of talent and time. If you're familiar with javascript and willing to help, contact me via <a href="https://github.com/MrFarland">GitHub</a>.</p>
 

--- a/Module/09-Equipment/adventuring_gear.md
+++ b/Module/09-Equipment/adventuring_gear.md
@@ -10,8 +10,7 @@ parent: equipment
 | :----------------------------------------------------- | -------: | -----------: |
 | [Abacus](/item/abacus)                                 |     2 gp |        2 lb. |
 | [Acid (vial)](/item/acid-vial)                         |    25 gp |        1 lb. |
-| [Alchemist's Fire (flask)](/item/alchemists-fire-flask)
-|    50 gp |        1 lb. |
+| [Alchemist's Fire (flask)](/item/alchemists-fire-flask)|    50 gp |        1 lb. |
 | **Ammunition**                                                                 |||
 | - [Arrows](/item/arrows) (20)                          |     1 gp |        1 lb. |
 | - [Blowgun Needles](/item/blowgun-needles) (50)        |     1 gp |        1 lb. |

--- a/Module/09-Equipment/weapons.md
+++ b/Module/09-Equipment/weapons.md
@@ -6,49 +6,49 @@ parent: equipment
 ### Weapons
 [Home](dm-operations-center) > [Equipment](equipment-menu) > Weapons {.small-text}
 
-| Item                                    | Cost| DMG                | Lbs | [Properties](weapon-properties) |
-| :-------------------------------------- | --: | ------------------: | --: | :------------------------------ |
-| **Simple Melee Weapons**                                                                                |||||
-| [Club](/item/club)                      |  1s | [1d4](/roll/1d4)B   |  2  | L                               |
-| [Dagger](/item/dagger)                  |  2g | [1d4](/roll/1d4)P   |  1  | F,L,T(20/60                     |
-| [Greatclub](/item/greatclub)            |  2s | [1d8](/roll/1d8)B   | 10  | 2H                              |
-| [Handaxe](/item/handaxe)                |  5g | [1d6](/roll/1d6)S   |  2  | L,T(20/60)                      |
-| [Javelin](/item/javelin)                |  5s | [1d6](/roll/1d6)P   |  2  | T(30/120)                       |
-| [Light Hammer](/item/light-hammer)      |  2g | [1d4](/roll/1d4)B   |  2  | L,T(20/60)                      |
-| [Mace](/item/mace)                      |  5g | [1d6](/roll/1d6)B   |  4  | ---                             |
-| [Quarterstaff](/item/quarterstaff)      |  2s | [1d6](/roll/1d6)B   |  4  | V                               |
-| [Sickle](/item/sickle)                  |  1g | [1d4](/roll/1d4)s   |  2  | L                               |
-| [Spear](/item/spear)                    |  1g | [1d6](/roll/1d6)p   |  3  | T(20/60),V                      |
-| **Simple Ranged Weapons**                                                                               |||||
-| [Crossbow, Light](/item/crossbow-light) | 25g | [1d8](/roll/1d8)P   |  5  | A(80/320), LD,2H                |
-| [Dart](/item/dart)                      |  5c | [1d4](/roll/1d4)P   | 1/4 | F,T(20/60)                      |
-| [Shortbow](/item/shortbow)              | 25g | [1d6](/roll/1d6)P   |  2  | A(80/320),2H                    |
-| [Sling](/item/sling)                    |  1s | [1d4](/roll/1d4)B   |  -  | A(30/120)                       |
-| **Martial Melee Weapons**                                                                               |||||
-| [Battlaxe](/item/battleaxe)             | 10g | [1d8](/roll/1d8)S   |  4  | V                               |
-| [Flail](/item/flail)                    | 10g | [1d8](/roll/1d8)B   |  2  |                                 |
-| [Glaive](/item/glaive)                  | 20g | [1d10](/roll/1d10)S |  6  | H,R,2H                          |
-| [Greataxe](/item/greataxe)              | 30g | [1d12](/roll/1d12)S |  7  | H,2H                            |
-| [Greatsword](/item/greatsword)          | 50g | [2d6](/roll/2d6)S   |  6  | H,2H                            |
-| [Halberd](/item/halberd)                | 20g | [1d10](/roll/1d10)S |  6  | H,R,2H                          |
-| [Lance](/item/lance)                    | 10g | [1d12](/roll/1d12)P |  6  | R,S                             |
-| [Longsword](/item/longsword)            | 15g | [1d8](/roll/1d8)S   |  3  | V                               |
-| [Maul](/item/maul)                      | 10g | [2d6](/roll/2d6)B   |  10 | H,2H                            |
-| [Morningstar](/item/morningstar)        | 15g | [1d8](/roll/1d8)P   |  4  |                                 |
-| [Pike](/item/pike)                      |  5g | [1d10](/roll/1d10)P |  18 | H,R,2H                          |
-| [Rapier](/item/rapier)                  | 25g | [1d8](/roll/1d8)P   |  2  | F                               |
-| [Scimitar](/item/scimitar)              | 25g | [1d6](/roll/1d6)S   |  3  | F,L                             |
-| [Shortsword](/item/shortsword)          | 10g | [1d6](/roll/1d6)P   |  2  | F,L                             |
-| [Trident](/item/trident)                |  5g | [1d6](/roll/1d6)P   |  4  | T(20/60),V                      |
-| [War Pick](/item/war-pick)              |  5g | [1d8](/roll/1d8)P   |  2  |                                 |
-| [Warhammer](/item/warhammer)            | 15g | [1d8](/roll/1d8)B   |  2  | V                               |
-| [Whip](/item/whip)                      |  2g | [1d4](/roll/1d4)S   |  3  | F,R                             |
-| **Martial Ranged Weapons**                                                                              |||||
-| [Blowgun](/item/blowgun)                | 10g | 1P                  |  1  | A(25/100),LD                    |
-| [Crossbow, Hand](/item/crossbow-hand)   | 75g | [1d6](/roll/1d6)P   |  3  | A(30/120),LD                    |
-| [Crossbow, Heavy](/item/crossbow-heavy) | 50g | [1d10](/roll/1d10)P | 18  | A(100/400),H, 2H,LD             |
-| [Longbow](/item/longbow)                | 50g | [1d8](/roll/1d8)P   |  2  | A(150/600),H, 2H                |
-| [Net](/item/net)                        |  1g | -                   |  3  | A(80/320),2H                    |
+| Item                                    | Cost  | DMG                 | Lbs | [Properties](weapon-properties) |
+| :-------------------------------------- | ----: | ------------------: | --: | :------------------------------ |
+| **Simple Melee Weapons**                                                                                  |||||
+| [Club](/item/club)                      |  1 sp | [1d4](/roll/1d4)B   |  2  | L                               |
+| [Dagger](/item/dagger)                  |  2 gp | [1d4](/roll/1d4)P   |  1  | F,L,T(20/60                     |
+| [Greatclub](/item/greatclub)            |  2 sp | [1d8](/roll/1d8)B   | 10  | 2H                              |
+| [Handaxe](/item/handaxe)                |  5 gp | [1d6](/roll/1d6)S   |  2  | L,T(20/60)                      |
+| [Javelin](/item/javelin)                |  5 sp | [1d6](/roll/1d6)P   |  2  | T(30/120)                       |
+| [Light Hammer](/item/light-hammer)      |  2 gp | [1d4](/roll/1d4)B   |  2  | L,T(20/60)                      |
+| [Mace](/item/mace)                      |  5 gp | [1d6](/roll/1d6)B   |  4  | ---                             |
+| [Quarterstaff](/item/quarterstaff)      |  2 sp | [1d6](/roll/1d6)B   |  4  | V                               |
+| [Sickle](/item/sickle)                  |  1 gp | [1d4](/roll/1d4)s   |  2  | L                               |
+| [Spear](/item/spear)                    |  1 gp | [1d6](/roll/1d6)p   |  3  | T(20/60),V                      |
+| **Simple Ranged Weapons**                                                                                 |||||
+| [Crossbow, Light](/item/crossbow-light) | 25 gp | [1d8](/roll/1d8)P   |  5  | A(80/320), LD,2H                |
+| [Dart](/item/dart)                      |  5 cp | [1d4](/roll/1d4)P   | 1/4 | F,T(20/60)                      |
+| [Shortbow](/item/shortbow)              | 25 gp | [1d6](/roll/1d6)P   |  2  | A(80/320),2H                    |
+| [Sling](/item/sling)                    |  1 sp | [1d4](/roll/1d4)B   |  -  | A(30/120)                       |
+| **Martial Melee Weapons**                                                                                 |||||
+| [Battlaxe](/item/battleaxe)             | 10 gp | [1d8](/roll/1d8)S   |  4  | V                               |
+| [Flail](/item/flail)                    | 10 gp | [1d8](/roll/1d8)B   |  2  |                                 |
+| [Glaive](/item/glaive)                  | 20 gp | [1d10](/roll/1d10)S |  6  | H,R,2H                          |
+| [Greataxe](/item/greataxe)              | 30 gp | [1d12](/roll/1d12)S |  7  | H,2H                            |
+| [Greatsword](/item/greatsword)          | 50 gp | [2d6](/roll/2d6)S   |  6  | H,2H                            |
+| [Halberd](/item/halberd)                | 20 gp | [1d10](/roll/1d10)S |  6  | H,R,2H                          |
+| [Lance](/item/lance)                    | 10 gp | [1d12](/roll/1d12)P |  6  | R,S                             |
+| [Longsword](/item/longsword)            | 15 gp | [1d8](/roll/1d8)S   |  3  | V                               |
+| [Maul](/item/maul)                      | 10 gp | [2d6](/roll/2d6)B   |  10 | H,2H                            |
+| [Morningstar](/item/morningstar)        | 15 gp | [1d8](/roll/1d8)P   |  4  |                                 |
+| [Pike](/item/pike)                      |  5 gp | [1d10](/roll/1d10)P |  18 | H,R,2H                          |
+| [Rapier](/item/rapier)                  | 25 gp | [1d8](/roll/1d8)P   |  2  | F                               |
+| [Scimitar](/item/scimitar)              | 25 gp | [1d6](/roll/1d6)S   |  3  | F,L                             |
+| [Shortsword](/item/shortsword)          | 10 gp | [1d6](/roll/1d6)P   |  2  | F,L                             |
+| [Trident](/item/trident)                |  5 gp | [1d6](/roll/1d6)P   |  4  | T(20/60),V                      |
+| [War Pick](/item/war-pick)              |  5 gp | [1d8](/roll/1d8)P   |  2  |                                 |
+| [Warhammer](/item/warhammer)            | 15 gp | [1d8](/roll/1d8)B   |  2  | V                               |
+| [Whip](/item/whip)                      |  2 gp | [1d4](/roll/1d4)S   |  3  | F,R                             |
+| **Martial Ranged Weapons**                                                                                |||||
+| [Blowgun](/item/blowgun)                | 10 gp | 1P                  |  1  | A(25/100),LD                    |
+| [Crossbow, Hand](/item/crossbow-hand)   | 75 gp | [1d6](/roll/1d6)P   |  3  | A(30/120),LD                    |
+| [Crossbow, Heavy](/item/crossbow-heavy) | 50 gp | [1d10](/roll/1d10)P | 18  | A(100/400),H, 2H,LD             |
+| [Longbow](/item/longbow)                | 50 gp | [1d8](/roll/1d8)P   |  2  | A(150/600),H, 2H                |
+| [Net](/item/net)                        |  1 gp | -                   |  3  | A(80/320),2H                    |
 {.gray .small-text}
 
 > **Sources** <br/>

--- a/Module/10-Expenses/upkeep.md
+++ b/Module/10-Expenses/upkeep.md
@@ -10,21 +10,21 @@ The per-day costs of various types of property are indicated below and include t
 
 | Property               | Cost   | SH   | US   |
 | :--------------------- | -----: | ---: | ---: |
-| Abbey                  |    20g |    5 |   25 |
-| Farm                   |     5s |    1 |    2 |
-| Guildhall (Town, City) |     5g |    5 |    3 |
-| Inn (Rural, Roadside)  |    10g |    5 |   10 |
-| Inn (Town, City)       |     5g |    1 |    5 |
-| Keep, Small Castle     |   100g |   50 |   50 |
-| Lodge, Hunting         |     5s |    1 |    - |
-| Noble Estate           |    10g |    3 |   15 |
-| Outpost, Fort          |    50g |   20 |   40 |
-| Palace, Large Castle   |   400g |  200 |  100 |
-| Shop                   |     2g |    1 |    - |
-| Temple, Large          |    25g |   10 |   10 |
-| Temple, Small          |     1g |    2 |    - |
-| Tower                  |    25g |   10 |    - |
-| Trading Post           |    10g |    4 |    2 |
+| Abbey                  |  20 gp |    5 |   25 |
+| Farm                   |   5 sp |    1 |    2 |
+| Guildhall (Town, City) |   5 gp |    5 |    3 |
+| Inn (Rural, Roadside)  |  10 gp |    5 |   10 |
+| Inn (Town, City)       |   5 gp |    1 |    5 |
+| Keep, Small Castle     | 100 gp |   50 |   50 |
+| Lodge, Hunting         |   5 sp |    1 |    - |
+| Noble Estate           |  10 gp |    3 |   15 |
+| Outpost, Fort          |  50 gp |   20 |   40 |
+| Palace, Large Castle   | 400 gp |  200 |  100 |
+| Shop                   |   2 gp |    1 |    - |
+| Temple, Large          |  25 gp |   10 |   10 |
+| Temple, Small          |   1 gp |    2 |    - |
+| Tower                  |  25 gp |   10 |    - |
+| Trading Post           |  10 gp |    4 |    2 |
 {.gray .small-text}
 
 Soldiers tasked with the defense of the property should use the [Guard](/monster/guard) or [Veteran](/monster/veteran) NPC templates.

--- a/Module/13-Spellcasting/13-spellcasting-menu.md
+++ b/Module/13-Spellcasting/13-spellcasting-menu.md
@@ -12,7 +12,7 @@ parent: dm-operations-center
     <a href="concentration">Concentration</a>
     <a href="counterspell">Counterspell</a>
     <a href="identify-spell">Identify<br/> Spell</a>
-    <a href="known-and-prepared">Known &<br/> Prepared Spells</a>
+    <a href="known-and-prepared-spells">Known &<br/> Prepared Spells</a>
     <a href="ritual-cast">Ritual<br/> Cast</a>
     <a href="schools-of-magic">Schools<br/> of Magic</a>
     <a href="copy-scroll">Scroll<br/> (Copy)</a>


### PR DESCRIPTION
Found a few minor corrections that I missed before. 

Upkeep: missing space and p on coin value
Known & Prepared Spells: linked page missing
Adventuring Gear: Alchemist’s Fire (flask) row fix
Weapons: cost column missing p on coin value
Encounters: gif not centered
Sell Magic Item: needed space between coin values
Research: needed space between coin values